### PR TITLE
topic branches repos

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -31,6 +31,11 @@
   * Follow [Dockerflow specification](https://github.com/mozilla-services/Dockerflow)
   * Use third party development tools for code coverage, documentation, etc.
 
+* **DOs and DONTs**
+
+  * **DO** push your `git` topic branches to **your fork** (not `mozilla`) and make
+    your pull request from there to the main repo. 
+    
 ## Projects
 
 * **SHOULD**


### PR DESCRIPTION
* Ownership is immediately obvious. Especially when you expand the "Branch: ..." drop down, since the only way to find out *who* it belongs to is to open the branch and look at the last committer.
* Branches inside the main repo are for things like `gh-pages` or `dev` (if you use that) or any other big project topic branch that many people are in on.
* If a PR is left incomplete but urgent and the owner is on vacation, team members with write access already have the write access to their peers branches if they need to move a PR forward.
* A *disadvantage* with using your fork is that you can't use CircleCI to make PR building exclusive to those with write access. CircleCI can already protect secrets on a project from other peoples fork branches's circle builds.