### PR TITLE
Add bors to "repositories should" section

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -21,6 +21,7 @@
   * Use a GitHub Project to track statuses of issues
   * Use CircleCI for continuous integration
   * Follow [Dockerflow specification](https://github.com/mozilla-services/Dockerflow)
+  * Use [bors](https://bors.tech) for merging.
   
 * **MAY**
 


### PR DESCRIPTION
I don't see a good place to put a "how to use bors" set of docs. Any suggestions?